### PR TITLE
Re-add some exceptions so that the compiler doesn't silently fail

### DIFF
--- a/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
@@ -515,21 +515,25 @@ namespace UdonSharp
             return outSymbol;
         }
 
-        public SymbolDefinition destinationSymbolForSet { 
+        public SymbolDefinition destinationSymbolForSet
+        { 
             get
             {
                 if (captureArchetype == ExpressionCaptureArchetype.LocalSymbol)
                 {
-                    if (captureLocalSymbol.declarationType.HasFlag(SymbolDeclTypeFlags.Constant) || captureLocalSymbol.declarationType.HasFlag(SymbolDeclTypeFlags.This))
-                        return null;
+                    if (captureLocalSymbol.declarationType.HasFlag(SymbolDeclTypeFlags.Constant))
+                        throw new System.Exception("Cannot execute set on constant symbols");
+                    else if (captureLocalSymbol.declarationType.HasFlag(SymbolDeclTypeFlags.This))
+                        throw new System.Exception("Cannot execute set on `this` symbols");
 
                     return captureLocalSymbol;
-                } else
+                }
+                else
                 {
                     return null;
                 }
             } 
-        }
+        } 
 
         public void ExecuteSet(SymbolDefinition value, bool explicitCast = false)
         {


### PR DESCRIPTION
Re-add some exceptions so that the compiler doesn't silently skip copying a value instead of throwing an exception since something is wrong. @bdunderscore is there a reason that these should be left out? I noticed they were removed in the COW changes.