### PR TITLE
Use upcoming Utilities.IsValid method to check for UnityObject null

### DIFF
--- a/Assets/UdonSharp/Tests/TestScripts/Canny/ObjectDestroyNullCheck.cs
+++ b/Assets/UdonSharp/Tests/TestScripts/Canny/ObjectDestroyNullCheck.cs
@@ -18,7 +18,7 @@ namespace UdonSharp.Tests
         {
             DestroyImmediate(refObject);
 
-            tester.TestAssertion("Object Destroy Null Check", refObject == null);
+            tester.TestAssertion("Object Destroy Null Check", !Utilities.IsValid(refObject));
         }
     }
 }


### PR DESCRIPTION
fixes ObjectDestroyNullCheck test and canny report