### PR TITLE
Improve the Create Script default write location

### DIFF
--- a/Assets/UdonSharp/Editor/Editors/UdonSharpGUI.cs
+++ b/Assets/UdonSharp/Editor/Editors/UdonSharpGUI.cs
@@ -440,10 +440,8 @@ namespace UdonSharpEditor
             if (GUILayout.Button("Create Script"))
             {
                 string thisPath = AssetDatabase.GetAssetPath(programAsset);
-                //string initialPath = Path.GetDirectoryName(thisPath);
                 string fileName = Path.GetFileNameWithoutExtension(thisPath).Replace(" Udon C# Program Asset", "").Replace(" ", "").Replace("#", "Sharp");
-
-                string chosenFilePath = EditorUtility.SaveFilePanelInProject("Save UdonSharp File", fileName, "cs", "Save UdonSharp file");
+                string chosenFilePath = EditorUtility.SaveFilePanelInProject("Save UdonSharp File", fileName, "cs", "Save UdonSharp file", Path.GetDirectoryName(thisPath));
 
                 if (chosenFilePath.Length > 0)
                 {


### PR DESCRIPTION
Minor UX fix so that clicking Create Script opens the file explorer to the same folder as the behaviour asset file.

Alternative fix would be a "create script in same folder" button but this is a more trivial change.