### PR TITLE
Fix GetComponent/GetComponents displays error log

### DIFF
--- a/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
@@ -1248,6 +1248,29 @@ namespace UdonSharp.Compiler
                 componentValue = CastSymbolToType(componentArrayGetter.ExecuteGet(), udonSharpType, true, true);
             }
 
+            SymbolDefinition objectTypeIdType = null;
+
+            using (ExpressionCaptureScope typeIDTypeGetScope = new ExpressionCaptureScope(visitorContext, null))
+            {
+                typeIDTypeGetScope.SetToLocalSymbol(componentValue);
+                SymbolDefinition udonTypeIdSymbolName = visitorContext.topTable.CreateConstSymbol(typeof(string), visitorContext.topTable.CreateReflectionSymbol("udonTypeID", typeof(long), Internal.UdonSharpInternalUtility.GetTypeID(visitorContext.behaviourUserType)).symbolUniqueName);
+                typeIDTypeGetScope.ResolveAccessToken(nameof(VRC.Udon.UdonBehaviour.GetProgramVariableType));
+
+                objectTypeIdType = typeIDTypeGetScope.Invoke(new SymbolDefinition[] { udonTypeIdSymbolName });
+            }
+
+            SymbolDefinition typeIdTypeEqualsConditionSymbol = null;
+
+            using (ExpressionCaptureScope equalsConditionScope = new ExpressionCaptureScope(visitorContext, null))
+            {
+                equalsConditionScope.SetToMethods(UdonSharpUtils.GetOperators(typeof(System.Type), BuiltinOperatorType.Equality));
+                typeIdTypeEqualsConditionSymbol = equalsConditionScope.Invoke(new SymbolDefinition[] { objectTypeIdType, visitorContext.topTable.CreateConstSymbol(typeof(System.Type), componentTypeID.symbolCsType) });
+            }
+
+            JumpLabel conditionFalseJumpLoc = visitorContext.labelTable.GetNewJumpLabel("genericGetUserComponentIdNotEqual");
+
+            visitorContext.uasmBuilder.AddJumpIfFalse(conditionFalseJumpLoc, typeIdTypeEqualsConditionSymbol);
+
             SymbolDefinition objectTypeId = null;
 
             using (ExpressionCaptureScope typeIDGetScope = new ExpressionCaptureScope(visitorContext, null))
@@ -1265,8 +1288,6 @@ namespace UdonSharp.Compiler
                 equalsConditionScope.SetToMethods(UdonSharpUtils.GetOperators(typeof(long), BuiltinOperatorType.Equality));
                 typeIdEqualsConditionSymbol = equalsConditionScope.Invoke(new SymbolDefinition[] { objectTypeId, componentTypeID });
             }
-
-            JumpLabel conditionFalseJumpLoc = visitorContext.labelTable.GetNewJumpLabel("genericGetUserComponentIdNotEqual");
 
             visitorContext.uasmBuilder.AddJumpIfFalse(conditionFalseJumpLoc, typeIdEqualsConditionSymbol);
 
@@ -1370,6 +1391,29 @@ namespace UdonSharp.Compiler
                     componentValue = CastSymbolToType(componentArrayGetter.ExecuteGet(), udonSharpType, true, true);
                 }
 
+                SymbolDefinition objectTypeIdType = null;
+
+                using (ExpressionCaptureScope typeIDTypeGetScope = new ExpressionCaptureScope(visitorContext, null))
+                {
+                    typeIDTypeGetScope.SetToLocalSymbol(componentValue);
+                    SymbolDefinition udonTypeIdSymbolName = visitorContext.topTable.CreateConstSymbol(typeof(string), visitorContext.topTable.CreateReflectionSymbol("udonTypeID", typeof(long), Internal.UdonSharpInternalUtility.GetTypeID(visitorContext.behaviourUserType)).symbolUniqueName);
+                    typeIDTypeGetScope.ResolveAccessToken(nameof(VRC.Udon.UdonBehaviour.GetProgramVariableType));
+
+                    objectTypeIdType = typeIDTypeGetScope.Invoke(new SymbolDefinition[] { udonTypeIdSymbolName });
+                }
+
+                SymbolDefinition typeIdTypeEqualsConditionSymbol = null;
+
+                using (ExpressionCaptureScope equalsConditionScope = new ExpressionCaptureScope(visitorContext, null))
+                {
+                    equalsConditionScope.SetToMethods(UdonSharpUtils.GetOperators(typeof(System.Type), BuiltinOperatorType.Equality));
+                    typeIdTypeEqualsConditionSymbol = equalsConditionScope.Invoke(new SymbolDefinition[] { objectTypeIdType, visitorContext.topTable.CreateConstSymbol(typeof(System.Type), componentTypeID.symbolCsType) });
+                }
+
+                JumpLabel incrementConditionFalseJump = visitorContext.labelTable.GetNewJumpLabel("genericGetUserComponentsIncrementConditionFalse");
+
+                visitorContext.uasmBuilder.AddJumpIfFalse(incrementConditionFalseJump, typeIdTypeEqualsConditionSymbol);
+
                 SymbolDefinition objectTypeId = null;
 
                 using (ExpressionCaptureScope typeIDGetScope = new ExpressionCaptureScope(visitorContext, null))
@@ -1379,8 +1423,6 @@ namespace UdonSharp.Compiler
 
                     objectTypeId = typeIDGetScope.Invoke(new SymbolDefinition[] { });
                 }
-
-                JumpLabel incrementConditionFalseJump = visitorContext.labelTable.GetNewJumpLabel("genericGetUserComponentsIncrementConditionFalse");
 
                 SymbolDefinition incrementConditionSymbol = null;
 
@@ -1486,6 +1528,29 @@ namespace UdonSharp.Compiler
                     componentValue = CastSymbolToType(componentArrayGetter.ExecuteGet(), udonSharpType, true, true);
                 }
 
+                SymbolDefinition objectTypeIdType = null;
+
+                using (ExpressionCaptureScope typeIDTypeGetScope = new ExpressionCaptureScope(visitorContext, null))
+                {
+                    typeIDTypeGetScope.SetToLocalSymbol(componentValue);
+                    SymbolDefinition udonTypeIdSymbolName = visitorContext.topTable.CreateConstSymbol(typeof(string), visitorContext.topTable.CreateReflectionSymbol("udonTypeID", typeof(long), Internal.UdonSharpInternalUtility.GetTypeID(visitorContext.behaviourUserType)).symbolUniqueName);
+                    typeIDTypeGetScope.ResolveAccessToken(nameof(VRC.Udon.UdonBehaviour.GetProgramVariableType));
+
+                    objectTypeIdType = typeIDTypeGetScope.Invoke(new SymbolDefinition[] { udonTypeIdSymbolName });
+                }
+
+                SymbolDefinition typeIdTypeEqualsConditionSymbol = null;
+
+                using (ExpressionCaptureScope equalsConditionScope = new ExpressionCaptureScope(visitorContext, null))
+                {
+                    equalsConditionScope.SetToMethods(UdonSharpUtils.GetOperators(typeof(System.Type), BuiltinOperatorType.Equality));
+                    typeIdTypeEqualsConditionSymbol = equalsConditionScope.Invoke(new SymbolDefinition[] { objectTypeIdType, visitorContext.topTable.CreateConstSymbol(typeof(System.Type), componentTypeID.symbolCsType) });
+                }
+
+                JumpLabel addConditionFalseJump = visitorContext.labelTable.GetNewJumpLabel("genericGetUserComponentsAddConditionFalse");
+
+                visitorContext.uasmBuilder.AddJumpIfFalse(addConditionFalseJump, typeIdTypeEqualsConditionSymbol);
+
                 SymbolDefinition objectTypeId = null;
 
                 using (ExpressionCaptureScope typeIDGetScope = new ExpressionCaptureScope(visitorContext, null))
@@ -1495,8 +1560,6 @@ namespace UdonSharp.Compiler
 
                     objectTypeId = typeIDGetScope.Invoke(new SymbolDefinition[] { });
                 }
-
-                JumpLabel addConditionFalseJump = visitorContext.labelTable.GetNewJumpLabel("genericGetUserComponentsAddConditionFalse");
 
                 SymbolDefinition addConditionSymbol = null;
 


### PR DESCRIPTION
An error log may be output when trying to get a user class type component with GetComponent(s).

The reason for this is that GetProgramVariable() is trying to get "__refl_const_intnl_udonTypeID" for Udon other than UdonSharp.
I don't know when it started behaving this way, but GetProgramVariable() now outputs an error log when it tries to get a non-existent variable.
GetProgramVariableType() does not output an error if you specify a non-existent variable, so you can use it to verify the existence of the variable. The error can be avoided by proceeding only when the type can be obtained.
This problem is limited to editors, but it is very annoying because the error is always displayed.

**error log:**
```
[UdonBehaviour] Could not find symbol __refl_const_intnl_udonTypeID; available: []
[UdonBehaviour] Could not find symbol __refl_const_intnl_udonTypeID; available: []
```

**example code:**
```C#
public class Example : UdonSharpBehaviour
{
    private void Start()
    {
        var _ = GetComponents<Example>();
    }
}
```
**example scene:**
![image](https://user-images.githubusercontent.com/8447771/132316900-0dc89699-3c05-4b55-bf61-6853b3b535b9.png)

