### PR TITLE
Make InteractToggle null safe.

### DIFF
--- a/Assets/UdonSharp/Examples/Utilities/InteractToggle.cs
+++ b/Assets/UdonSharp/Examples/Utilities/InteractToggle.cs
@@ -19,7 +19,9 @@ namespace UdonSharp.Examples.Utilities
         {
             foreach (GameObject toggleObject in toggleObjects)
             {
-                toggleObject.SetActive(!toggleObject.activeSelf);
+                if (toggleObject != null) {
+                    toggleObject.SetActive(!toggleObject.activeSelf);
+                }
             }
         }
     }


### PR DESCRIPTION
InteractToggle crashes if an entry in toggleObjects is null, which happens when an entry is deleted. Example scripts probably should not have very easy ways of crashing them!