### PR TITLE
Improve bitwise NOT code generation for signed types

### DIFF
--- a/Assets/UdonSharp/Editor/Compiler/Binder/BoundNodes/BoundBitwiseNotExpression.cs
+++ b/Assets/UdonSharp/Editor/Compiler/Binder/BoundNodes/BoundBitwiseNotExpression.cs
@@ -19,9 +19,18 @@ namespace UdonSharp.Compiler.Binder
         public override Value EmitValue(EmitContext context)
         {
             Type operandType = ValueType.UdonType.SystemType;
-            
-            object maxIntVal = operandType.GetField("MaxValue").GetValue(null);
-            BoundAccessExpression maxVal = BoundAccessExpression.BindAccess(context.GetConstantValue(ValueType, maxIntVal));
+
+            object allBits;
+
+            if (UdonSharpUtils.IsSignedType(operandType))
+            {
+                allBits = Convert.ChangeType(-1, operandType);
+            } else
+            {
+                allBits = operandType.GetField("MaxValue").GetValue(null);
+            }
+
+            BoundAccessExpression allBitsExpr = BoundAccessExpression.BindAccess(context.GetConstantValue(ValueType, allBits));
 
             Value returnValue = context.GetReturnValue(ValueType);
 
@@ -32,58 +41,7 @@ namespace UdonSharp.Compiler.Binder
                 context.EmitValueAssignment(returnValue,
                     CreateBoundInvocation(context, null,
                         new ExternSynthesizedOperatorSymbol(BuiltinOperatorType.LogicalXor, ValueType, context), null,
-                        new BoundExpression[] { operandVal, maxVal }));
-
-                if (UdonSharpUtils.IsSignedType(operandType)) // Signed types need handling for negating the sign
-                {
-                    Value isNegative = context.EmitValue(CreateBoundInvocation(context, null,
-                        new ExternSynthesizedOperatorSymbol(BuiltinOperatorType.LessThan, ValueType, context), null,
-                        new BoundExpression[]
-                        {
-                            operandVal,
-                            BoundAccessExpression.BindAccess(context.GetConstantValue(ValueType,
-                                Convert.ChangeType(0, operandType)))
-                        }));
-
-                    JumpLabel exitLabel = context.Module.CreateLabel();
-                    JumpLabel falseLabel = context.Module.CreateLabel();
-                    
-                    context.Module.AddJumpIfFalse(falseLabel, isNegative);
-
-                    context.EmitValueAssignment(returnValue,
-                        CreateBoundInvocation(context, null,
-                            new ExternSynthesizedOperatorSymbol(BuiltinOperatorType.LogicalAnd, ValueType, context),
-                            null, new BoundExpression[] { BoundAccessExpression.BindAccess(returnValue), maxVal }));
-                    
-                    context.Module.AddJump(exitLabel);
-                    context.Module.LabelJump(falseLabel);
-                    
-                    long bitOr = 0;
-
-                    if (operandType == typeof(sbyte))
-                        bitOr = 1 << 7;
-                    else if (operandType == typeof(short))
-                        bitOr = 1 << 15;
-                    else if (operandType == typeof(int))
-                        bitOr = 1 << 31;
-                    else if (operandType == typeof(long))
-                        bitOr = (long)1 << 63;
-                    else
-                        throw new Exception();
-
-                    context.EmitValueAssignment(returnValue,
-                        CreateBoundInvocation(context, null,
-                            new ExternSynthesizedOperatorSymbol(BuiltinOperatorType.LogicalOr, ValueType, context),
-                            null,
-                            new BoundExpression[]
-                            {
-                                BoundAccessExpression.BindAccess(returnValue),
-                                BoundAccessExpression.BindAccess(context.GetConstantValue(ValueType,
-                                    Convert.ChangeType(bitOr, operandType)))
-                            }));
-                    
-                    context.Module.LabelJump(exitLabel);
-                }
+                        new BoundExpression[] { operandVal, allBitsExpr }));
             }
 
             return returnValue;

--- a/Assets/UdonSharp/Tests/TestScripts/Core/ArithmeticTest.cs
+++ b/Assets/UdonSharp/Tests/TestScripts/Core/ArithmeticTest.cs
@@ -401,6 +401,12 @@ namespace UdonSharp.Tests
             uint resultUint = ~uintTest;
             tester.TestAssertion("uint bitwise not", ~uintTest == 4294967255);
             tester.TestAssertion("uint bitwise not 2", resultUint == 4294967255);
+
+            long la = (long)0x1111111111111111;
+            long lb = (long)~la;
+
+            tester.TestAssertion("Long bitwise NOT 1", lb == -0x1111111111111112);
+            tester.TestAssertion("Long bitwise NOT 2", ~lb == la);
         }
     }
 }


### PR DESCRIPTION
We can avoid needing a branch by using an XOR of the signed
representation of -1 to implement bitwise NOT for signed types.