### PR TITLE
Fix for ReflectionTypeLoadException

### DIFF
--- a/Assets/UdonSharp/Editor/Editors/UdonSharpBehaviourEditor.cs
+++ b/Assets/UdonSharp/Editor/Editors/UdonSharpBehaviourEditor.cs
@@ -257,7 +257,7 @@ namespace UdonSharpEditor
 
             foreach (Assembly asm in UdonSharpUtils.GetLoadedEditorAssemblies())
             {
-                foreach (Type editorType in asm.GetTypes())
+                foreach (Type editorType in asm.GetTypesSafe())
                 {
                     IEnumerable<CustomEditor> editorAttributes = editorType.GetCustomAttributes<CustomEditor>();
 

--- a/Assets/UdonSharp/Editor/Editors/UdonTypeExposureTree.cs
+++ b/Assets/UdonSharp/Editor/Editors/UdonTypeExposureTree.cs
@@ -503,7 +503,7 @@ namespace UdonSharp.Editors
                         assembly.FullName.Contains("CodeAnalysis"))
                         continue;
 
-                    System.Type[] assemblyTypes = assembly.GetTypes();
+                    System.Type[] assemblyTypes = assembly.GetTypesSafe();
 
                     List<System.Type> types = new List<System.Type>();
 

--- a/Assets/UdonSharp/Editor/UdonSharpEditorManager.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpEditorManager.cs
@@ -75,7 +75,7 @@ namespace UdonSharpEditor
 
             foreach (Assembly assembly in UdonSharpUtils.GetLoadedEditorAssemblies())
             {
-                foreach (System.Type type in assembly.GetTypes())
+                foreach (System.Type type in assembly.GetTypesSafe())
                 {
                     if (type != typeof(UdonSharpBehaviour) && type.IsSubclassOf(typeof(UdonSharpBehaviour)))
                         udonSharpBehaviourTypes.Add(type);
@@ -388,7 +388,7 @@ namespace UdonSharpEditor
 
                 try
                 {
-                    types = assembly.GetTypes();
+                    types = assembly.GetTypesSafe();
                 }
                 catch (ReflectionTypeLoadException e)
                 {

--- a/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
+++ b/Assets/UdonSharp/Editor/UdonSharpExpressionCapture.cs
@@ -192,7 +192,7 @@ namespace UdonSharp.Compiler
 
                 foreach (Assembly assembly in System.AppDomain.CurrentDomain.GetAssemblies())
                 {
-                    allLinkedNamespaces.UnionWith(assembly.GetTypes().Select(e => e.Namespace).Distinct());
+                    allLinkedNamespaces.UnionWith(assembly.GetTypesSafe().Select(e => e.Namespace).Distinct());
                 }
 
                 namespacesInit = true;


### PR DESCRIPTION
This is minor fix for ReflectionTypeLoadException.

Some large VRChat projects can contain problematic and/or outdated 3rd party assemblies that can not be fully loaded. This does not cause any compilation errors or any other kind of problems in Unity Editor or VRCSDK if broken features is not used. However, if this kind of assembly is inspected, then ReflectionTypeLoadException will be thrown.

In case of UdonSharp, this breaks udon scripts compilation at all, as UdonSharp inspects all loaded assemblies. [I meet this error by myself before.](https://discord.com/channels/652715801714884620/675466846127915019/757416408719032351) And I meet people who encounter this problem time-to-time. I hope this will increase stability of projects using lots of assets from different sources.