### PR TITLE
Added Option to Parse Logs Directly from File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ Packages/*
 
 # UdonSharp stuff
 # Except UdonSharp folder from Packages/* rule
-!Packages/com.vrchat.UdonSharp/
+!Packages/com.merlin.UdonSharp/
 /Assets/UdonSharp/UdonSharpSettings.asset
 /Assets/UdonSharp/UdonSharpSettings.asset.meta
 Assets/Merlin.meta
@@ -119,5 +119,4 @@ Assets/Scenes/VRCDefaultWorldScene.unity
 Assets/XR
 Assets/Scenes.meta
 Assets/XR.meta
-Packages/com.vrchat.core.vpm-resolver
 Packages/com.vrchat.core.vpm-resolver

--- a/Packages/com.merlin.UdonSharp/Editor/Editors/LogFileParseUtility.cs
+++ b/Packages/com.merlin.UdonSharp/Editor/Editors/LogFileParseUtility.cs
@@ -1,0 +1,73 @@
+
+using System;
+using System.IO;
+using JetBrains.Annotations;
+using UdonSharp;
+using UnityEditor;
+using UnityEngine;
+
+namespace UdonSharpEditor
+{
+    public static class LogFileParseUtility
+    {
+        [MenuItem("VRChat SDK/Udon Sharp/Parse Logs from File")]
+        private static void ParseLogsFromFileMenuItem()
+        {
+            string filePath = EditorUtility.OpenFilePanel("Parse VRChat Log File", "", "txt");
+            if (string.IsNullOrWhiteSpace(filePath))
+                return;
+            
+            ParseLogsFromFile(filePath);
+        }
+
+        [PublicAPI]
+        public static void ParseLogsFromFile(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                UdonSharpUtils.LogError("Empty or Invalid path was provided for log file.");
+                return;
+            }
+
+            try
+            {
+                FileInfo fileInfo = new FileInfo(filePath);
+
+                string contents;
+
+                using (FileStream stream = fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    using (StreamReader reader = new StreamReader(stream))
+                    {
+                        reader.BaseStream.Position = 0;
+
+                        contents = reader.ReadToEnd();
+
+                        reader.Close();
+                    }
+
+                    stream.Close();
+                }
+
+                string username = null;
+                // Search for the player name that this log belongs to
+                const string searchStr = "User Authenticated: ";
+                int userIdx = contents.IndexOf(searchStr, StringComparison.Ordinal);
+                if (userIdx != -1)
+                {
+                    userIdx += searchStr.Length;
+
+                    int endIdx = contents.IndexOf(" (", userIdx, StringComparison.Ordinal);
+
+                    username = contents.Substring(userIdx, endIdx - userIdx);
+                }
+                
+                RuntimeLogWatcher.ParseLogText(contents, username);
+            }
+            catch (IOException e)
+            {
+                UdonSharpUtils.LogError("An exception occured when trying to access the provided log file: " + e.Message);
+            }
+        }
+    }
+}

--- a/Packages/com.merlin.UdonSharp/Editor/Editors/LogFileParseUtility.cs.meta
+++ b/Packages/com.merlin.UdonSharp/Editor/Editors/LogFileParseUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4e5696c77476984984245f11cd67659
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.merlin.UdonSharp/Editor/UdonSharpRuntimeLogWatcher.cs
+++ b/Packages/com.merlin.UdonSharp/Editor/UdonSharpRuntimeLogWatcher.cs
@@ -267,24 +267,13 @@ namespace UdonSharpEditor
                 if (udonSharpSettings.listenForVRCExceptions)
                 {
                     // Exception handling
-                    const string errorMatchStr = "[UdonBehaviour] An exception occurred during Udon execution, this UdonBehaviour will be halted.";
-
-                    int currentErrorIndex = contents.IndexOf(errorMatchStr, StringComparison.Ordinal);
-                    while (currentErrorIndex != -1)
-                    {
-                        HandleLogError(contents.Substring(currentErrorIndex, contents.Length - currentErrorIndex), "VRChat client runtime Udon exception detected!", $"{ state.playerName ?? "Unknown"}");
-
-                        currentErrorIndex = contents.IndexOf(errorMatchStr, currentErrorIndex + errorMatchStr.Length, StringComparison.Ordinal);
-                    }
+                    ParseLogErrors(contents, state);
                 }
             }
         }
-        
+
         private static string GetRandomColorStrFromName(string name)
         {
-
-            string username;
-            string logPath;
             Random random = new Random((name).GetHashCode());
 
             Color randomUserColor = Color.HSVToRGB((float)random.NextDouble(),  EditorGUIUtility.isProSkin ? 0.6f : 1.00f, EditorGUIUtility.isProSkin ? 0.9f : 0.6f);
@@ -307,6 +296,7 @@ namespace UdonSharpEditor
             }
             
             ParseLogText(contents, state, UdonSharpSettings.GetSettings());
+            ParseLogErrors(contents, state);
         }
         
         private static void ParseLogText(string contents, LogFileState state, UdonSharpSettings settings)
@@ -339,7 +329,7 @@ namespace UdonSharpEditor
                 {
                     logStr = contents.Substring(currentIdx < 0 ? 0 : currentIdx, match.Index - currentIdx);
                 }
-                else if (currentIdx != -1)
+                else
                 {
                     logStr = contents.Substring(currentIdx < 0 ? 0 : currentIdx, contents.Length - currentIdx);
                 }
@@ -351,6 +341,19 @@ namespace UdonSharpEditor
                     HandleForwardedLog(logStr, state, settings);
                 }
             } while (match.Success);
+        }
+        
+        private static void ParseLogErrors(string contents, LogFileState state)
+        {
+            const string errorMatchStr = "[UdonBehaviour] An exception occurred during Udon execution, this UdonBehaviour will be halted.";
+
+            int currentErrorIndex = contents.IndexOf(errorMatchStr, StringComparison.Ordinal);
+            while (currentErrorIndex != -1)
+            {
+                HandleLogError(contents.Substring(currentErrorIndex, contents.Length - currentErrorIndex), "VRChat client runtime Udon exception detected!", $"{ state.playerName ?? "Unknown"}");
+
+                currentErrorIndex = contents.IndexOf(errorMatchStr, currentErrorIndex + errorMatchStr.Length, StringComparison.Ordinal);
+            }
         }
 
         // Common messages that can spam the log and have no use for debugging
@@ -572,7 +575,7 @@ namespace UdonSharpEditor
             
             debugInfo.GetPositionFromProgramCounter(programCounter, out string filePath, out string methodName, out int line, out int lineChar);
 
-            UdonSharpUtils.LogRuntimeError($"{logPrefix}\n{errorMessage}", prePrefix != null ? $"[<color=#575ff2>{prePrefix}</color>]" : "", filePath, line, lineChar + 1, stackBuilder.ToString());
+            UdonSharpUtils.LogRuntimeError($"{logPrefix}\n{errorMessage}", prePrefix != null ? $"[<color=#{GetRandomColorStrFromName(prePrefix)}>{prePrefix}</color>]" : "", filePath, line, lineChar + 1, stackBuilder.ToString());
         }
     }
 }


### PR DESCRIPTION
Added the option to parse VRChat log files into a project to quickly see U# exceptions and have them appear in the Unity console.

- Quick option to parse logs given from other users, including in-line U# exceptions if applicable.
- Fixed an issue with random color from name not being used in U# exceptions specifically.
- Slight refactor to parsing code to open new api uses to parse other content via string text:
```cs
UdonSharpEditor.RuntimeLogWatcher.ParseLogText(string contents, string name)
```
https://github.com/user-attachments/assets/d1f204e9-0933-40ab-b8f2-37d209a4a62a

